### PR TITLE
Check for nil in GetAchievementInfo result

### DIFF
--- a/AchieveAcheFrame.lua
+++ b/AchieveAcheFrame.lua
@@ -41,11 +41,13 @@ function AchieveAche_LoadAchievementsFromApi()
 		c = GetCategoryNumAchievements(catid);
 		for i = 1, c do
 			id, name, points, completed, m, d, y, desc = GetAchievementInfo(catid, i);
-			if completed then
-				AchieveAche_CompletedAchievements[id] = { ["catid"] = catid, ["name"] = name, ["desc"] = desc };
-			else
-				AchieveAche_UncompletedAchievements[id] = { ["catid"] = catid, ["name"] = name, ["desc"] = desc };
-			end			
+			if (id ~= nil) then
+				if completed then
+					AchieveAche_CompletedAchievements[id] = { ["catid"] = catid, ["name"] = name, ["desc"] = desc };
+				else
+					AchieveAche_UncompletedAchievements[id] = { ["catid"] = catid, ["name"] = name, ["desc"] = desc };
+				end
+			end
 		end
 	end
 end
@@ -179,5 +181,3 @@ function Button3_OnClick()
 	EditBox1:SetText(sZone);
 	Button2_OnClick();
 end
-
-


### PR DESCRIPTION
Was getting the following error:

```
Date: 2016-09-07 02:47:27
ID: 1
Error occured in: Global
Count: 1
Message: ..\AddOns\achieveache\AchieveAcheFrame.lua line 47:
   table index is nil
Debug:
   achieveache\AchieveAcheFrame.lua:47: AchieveAche_LoadAchievementsFromApi()
   achieveache\AchieveAcheFrame.lua:26: ?()
...
```

So now it checks for `nil` in the `GetAchievementInfo` result. Might have something to do with [this](http://wowprogramming.com/docs/api/GetCategoryNumAchievements):

> BUG: for `includeSuperseded=false` the returned `numItems` is sometimes too high (as is `numUncompleted`)

But I tried it with `includeSuperseded=true`, but that still ends up with the last record being `nil`.
